### PR TITLE
YouTube Video for Reverse Engineering

### DIFF
--- a/content/cards/reverse-engineering.md
+++ b/content/cards/reverse-engineering.md
@@ -49,3 +49,5 @@ zooming: ""
 ---
 
 Ask participants to imagine that they're in a future where you've accomplished your goals or achieved perfection in regards to a particular concept. Viewing that finished product, what steps were taken to accomplish it? What pitfalls were avoided? Have them record their reflections on paper. State your intentions for sharing before they start writing.
+
+{{< youtube jE0EJLI2JtA >}}

--- a/layouts/cards/single.html
+++ b/layouts/cards/single.html
@@ -11,7 +11,7 @@
     <main class="content">
         <header>
             <h1>{{ .Title }}</h1>
-            <p class="card-blurb">{{ .Params.explanation }}</p>
+            <p class="card-blurb">{{ .Content }}</p>
         </header>
         <div class="content entry-content">
         <!-- {{ if .Params.general_notes }}


### PR DESCRIPTION
I'm taking a guess that the YouTube embeds are allowed in the markdown content (down where you first tried inserting the embed) but not in the "parameters" (e.g., "Explanation" ... all those values in the "frontmatter"). If that's true, then this PR should fix things... it prints the markdown content in place of the "Explanation" parameter. As long as those two texts match for all your Card posts, then you shouldn't notice changes on any other card pages. I checked a dozen of them, and that seemed to be true, but I recommend checking a couple more after this change gets published to be sure.